### PR TITLE
Include parameter info in the 'change' event

### DIFF
--- a/src/controls/Composer.js
+++ b/src/controls/Composer.js
@@ -117,7 +117,7 @@ ControlComposer.prototype._updateDynamics = function(storedDynamics, parameter, 
   parameterDynamics.dynamics.update(dynamics, (newTime - parameterDynamics.time)/1000);
   parameterDynamics.time = newTime;
 
-  this.emit('change');
+  this.emit('change', parameter, parameterDynamics, dynamics);
 };
 
 


### PR DESCRIPTION
This allows 'change' event listeners to know what has changed in the view.